### PR TITLE
Add optional cookie parameter to API client constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domrobot-client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "INWX Domrobot Node.JS Client",
   "author": "INWX Developer <developer@inwx.de> (https://inwx.com)",
   "main": "lib/index.js",

--- a/src/domrobot.ts
+++ b/src/domrobot.ts
@@ -20,12 +20,13 @@ export class ApiClient {
      * @param apiUrl url of the API.
      * @param language default language for future API requests.
      * @param debugMode whether requests and responses should be printed out.
+     * @param cookie Optional parameter to manually set the API cookie.
      */
-    constructor(apiUrl: string = ApiClient.API_URL_OTE, language: string = Language.EN, debugMode: boolean = false) {
+    constructor(apiUrl: string = ApiClient.API_URL_OTE, language: string = Language.EN, debugMode: boolean = false, cookie: string | null = null) {
         this.apiUrl = apiUrl;
         this.language = language;
         this.debugMode = debugMode;
-        this.cookie = null;
+        this.cookie = cookie !== undefined ? cookie : null;
     }
 
     /**


### PR DESCRIPTION
- Updated constructor to include an optional cookie parameter
- If the cookie parameter is not provided, it defaults to null
- Enhanced flexibility for API requests by allowing manual cookie setting